### PR TITLE
Session::set_item_str mutability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,7 @@ impl<'a> Session<'a> {
 
     /// Set string item to given Xpath.
     pub fn set_item_str(
-        &mut self,
+        &self,
         path: &str,
         value: &str,
         origin: Option<&str>,


### PR DESCRIPTION
set_item_str does not commit any changes and so it does not need mut permissions. This is backed by the sysrepo implementation.